### PR TITLE
Add 15 languages from weblate

### DIFF
--- a/ar.conf
+++ b/ar.conf
@@ -1,0 +1,2 @@
+Name=عربى
+LocaleCode=ar.utf8

--- a/es_AR.conf
+++ b/es_AR.conf
@@ -1,0 +1,2 @@
+Name=Español rioplatense
+LocaleCode=es_AR.utf8

--- a/fr_LU.conf
+++ b/fr_LU.conf
@@ -1,0 +1,2 @@
+Name=Lëtzebuergesch
+LocaleCode=fr_LU.utf8

--- a/gl.conf
+++ b/gl.conf
@@ -1,0 +1,2 @@
+Name=Galego
+LocaleCode=gl.utf8

--- a/id.conf
+++ b/id.conf
@@ -1,0 +1,2 @@
+Name=Bahasa Indonesia
+LocaleCode=id.utf8

--- a/ja_JP.conf
+++ b/ja_JP.conf
@@ -1,0 +1,2 @@
+Name=日本語
+LocaleCode=ja_JP.utf8

--- a/lt.conf
+++ b/lt.conf
@@ -1,0 +1,2 @@
+Name=Lietuvių
+LocaleCode=lt.utf8

--- a/mr.conf
+++ b/mr.conf
@@ -1,0 +1,2 @@
+Name=मराठी
+LocaleCode=mr.utf8

--- a/nl_BE.conf
+++ b/nl_BE.conf
@@ -1,0 +1,2 @@
+Name=Vlaams
+LocaleCode=nl_BE.utf8

--- a/pt.conf
+++ b/pt.conf
@@ -1,0 +1,2 @@
+Name=Português
+LocaleCode=pt.utf8

--- a/ro.conf
+++ b/ro.conf
@@ -1,0 +1,2 @@
+Name=Română
+LocaleCode=ro.utf8

--- a/ru_UA.conf
+++ b/ru_UA.conf
@@ -1,0 +1,2 @@
+Name=український
+LocaleCode=ru_UA.utf8

--- a/te.conf
+++ b/te.conf
@@ -1,0 +1,2 @@
+Name=తెలుగు
+LocaleCode=te.utf8

--- a/th_TH.conf
+++ b/th_TH.conf
@@ -1,0 +1,2 @@
+Name=ภาษาไทย
+LocaleCode=th_TH.utf8

--- a/vi_VN.conf
+++ b/vi_VN.conf
@@ -1,0 +1,2 @@
+Name=Tiếng Việt
+LocaleCode=vi_VN.utf8


### PR DESCRIPTION
While browsing weblate, several translations catched my eye that where not included in the nightlies
Went through all of the 46 available ones and found 15 of them to not be announced in `.../supported-languages/`.
Which is hereby fixed.